### PR TITLE
Add support for loading private key from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Below you will find some provisioning examples
 #### Using service account
 
 ```yaml
-# config file version
+# config file version (with private key in secureJsonData)
 apiVersion: 1
 datasources:
   - name: BigQuery DS
@@ -65,6 +65,22 @@ datasources:
       tokenUri: https://oauth2.googleapis.com/token
     secureJsonData:
       privateKey: your-private-key
+```
+
+```yaml
+# config file version (with private key file in jsonData)
+apiVersion: 1
+datasources:
+  - name: BigQuery DS
+    type: grafana-bigquery-datasource
+    editable: true
+    enabled: true
+    jsonData:
+      authenticationType: jwt
+      clientEmail: your-client-email
+      defaultProject: your-default-bigquery-project
+      tokenUri: https://oauth2.googleapis.com/token
+      privateKeyFile: '/etc/secrets/bigquery.pem'
 ```
 
 #### Using Google Metadata Server

--- a/pkg/bigquery/settings.go
+++ b/pkg/bigquery/settings.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/grafana/grafana-bigquery-datasource/pkg/bigquery/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -18,6 +19,19 @@ type Credentials struct {
 	TokenURI    string `json:"token_uri"`
 }
 
+func readPrivateKeyFromFile(rsaPrivateKeyLocation string) (string, error) {
+	if rsaPrivateKeyLocation == "" {
+		return "", fmt.Errorf("missing file location for private key")
+	}
+
+	privateKey, err := ioutil.ReadFile(rsaPrivateKeyLocation)
+	if err != nil {
+		return "", fmt.Errorf("could not read private key file from file system: %w", err)
+	}
+
+	return string(privateKey), nil
+}
+
 // LoadSettings will read and validate Settings from the DataSourceConfg
 func LoadSettings(config *backend.DataSourceInstanceSettings) (types.BigQuerySettings, error) {
 	settings := types.BigQuerySettings{}
@@ -25,7 +39,19 @@ func LoadSettings(config *backend.DataSourceInstanceSettings) (types.BigQuerySet
 		return settings, fmt.Errorf("could not unmarshal DataSourceInfo json: %w", err)
 	}
 
-	settings.PrivateKey = config.DecryptedSecureJSONData["privateKey"]
+	// Check if a private key file was provided. Always fall back to the plugin's default method
+	// of an inline private key
+	if settings.PrivateKeyFile != "" {
+		privateKey, err := readPrivateKeyFromFile(settings.PrivateKeyFile)
+		if err != nil {
+			return settings, fmt.Errorf("could not write private key to DataSourceInfo json: %w", err)
+		}
+
+		settings.PrivateKey = privateKey
+	} else {
+		settings.PrivateKey = config.DecryptedSecureJSONData["privateKey"]
+	}
+
 	settings.DatasourceId = config.ID
 	settings.Updated = config.Updated
 

--- a/pkg/bigquery/types/types.go
+++ b/pkg/bigquery/types/types.go
@@ -16,6 +16,7 @@ type BigQuerySettings struct {
 	ProcessingLocation string `json:"processingLocation"`
 	Updated            time.Time
 	AuthenticationType string `json:"authenticationType"`
+	PrivateKeyFile     string `json:"privateKeyFile"`
 
 	// Saved in secure JSON
 	PrivateKey string `json:"-"`


### PR DESCRIPTION
Prior, the private key needed to be embedded into the yaml config which is prone to failues by a faulty indentation. The option 'privateKeyFile' enables to read the private key from a file